### PR TITLE
FEAT - Speed Up Page Requests against SW API

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,7 @@ jobs:
           context: .
           push: true
           file: ./src/StarWars.AspNet.Api/Dockerfile
-          tags: ghcr.io/bashfulbandit/starwars.aspnet.api:latest,ghcr.io/bashfulbandit/starwars.aspnet.api:1.3.0
+          tags: ghcr.io/bashfulbandit/starwars.aspnet.api:latest,ghcr.io/bashfulbandit/starwars.aspnet.api:1.3.1
 
   publish-starwars-api-testcontainers:
     runs-on: ubuntu-latest

--- a/src/StarWars.AspNet.Api/StarWars.AspNet.Api.csproj
+++ b/src/StarWars.AspNet.Api/StarWars.AspNet.Api.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
 
     <PackageId>StarWars.AspNet.Api</PackageId>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Authors>Davis Templeton</Authors>
     <Company>Davis Templeton</Company>
     <Product>StarWars.AspNet.Api</Product>

--- a/src/StarWars.AspNet.SWAPI/Extensions/ICharactersStoreExtensions.cs
+++ b/src/StarWars.AspNet.SWAPI/Extensions/ICharactersStoreExtensions.cs
@@ -1,6 +1,5 @@
 using SWApiClient.Interfaces;
 using SWApiClient.Models;
-using SWApiClient.Responses.People;
 
 namespace StarWars.AspNet.SWAPI.Extensions;
 
@@ -14,17 +13,24 @@ internal static class ICharactersStoreExtensions
     {
         var people = new List<Person>();
 
-        var page = 0;
-        ListPeopleResponse? response;
-        do
+        // Get first page, so we can calculate how many other requests to make.
+        var firstPage = await client.ListAsync(new()
         {
-            response = await client.ListAsync(new()
-            {
-                Page = ++page
-            }, cancellation);
+            Page = 1
+        }, cancellation);
 
-            people.AddRange(response.Results);
-        } while (response.Next is not null);
+        // Create the Tasks for each page request.
+        var pages = await Task.WhenAll(
+            Enumerable.Range(2, (int) Math.Ceiling((double) (firstPage.Count - firstPage.Results.Count()) / firstPage.Results.Count()))
+            .Select(p => client.ListAsync(new()
+            {
+                Page = p
+            }, cancellation)));
+
+        // Add first page results and then the following page results.
+        // May need to consider possible duplicates, but that seems unlikely
+        // with the data coming from the SW API.
+        people.AddRange(firstPage.Results.Union(pages.SelectMany(p => p.Results)));
 
         return people;
     }

--- a/src/StarWars.AspNet.SWAPI/Extensions/ISpeciesClientExtensions.cs
+++ b/src/StarWars.AspNet.SWAPI/Extensions/ISpeciesClientExtensions.cs
@@ -1,6 +1,5 @@
 using SWApiClient.Interfaces;
 using SWApiClient.Models;
-using SWApiClient.Responses.Species;
 
 namespace StarWars.AspNet.SWAPI.Extensions;
 
@@ -23,17 +22,24 @@ internal static class ISpeciesClientExtensions
     {
         var species = new List<Species>();
 
-        var page = 0;
-        ListSpeciesResponse? response;
-        do
+        // Get first page, so we can calculate how many other requests to make.
+        var firstPage = await client.ListAsync(new()
         {
-            response = await client.ListAsync(new()
-            {
-                Page = ++page
-            }, cancellation);
+            Page = 1
+        }, cancellation);
 
-            species.AddRange(response.Results);
-        } while (response.Next is not null);
+        // Create the Tasks for each page request.
+        var pages = await Task.WhenAll(
+            Enumerable.Range(2, (int) Math.Ceiling((double) (firstPage.Count - firstPage.Results.Count()) / firstPage.Results.Count()))
+            .Select(p => client.ListAsync(new()
+            {
+                Page = p
+            }, cancellation)));
+
+        // Add first page results and then the following page results.
+        // May need to consider possible duplicates, but that seems unlikely
+        // with the data coming from the SW API.
+        species.AddRange(firstPage.Results.Union(pages.SelectMany(p => p.Results)));
 
         return species;
     }

--- a/src/StarWars.AspNet.SWAPI/Extensions/IStarshipsClientExtensions.cs
+++ b/src/StarWars.AspNet.SWAPI/Extensions/IStarshipsClientExtensions.cs
@@ -1,6 +1,5 @@
 using SWApiClient.Interfaces;
 using SWApiClient.Models;
-using SWApiClient.Responses.Starships;
 
 namespace StarWars.AspNet.SWAPI.Extensions;
 
@@ -23,17 +22,24 @@ internal static class IStarshipsClientExtensions
     {
         var starships = new List<Starship>();
 
-        var page = 0;
-        ListStarshipsResponse? response;
-        do
+        // Get first page, so we can calculate how many other requests to make.
+        var firstPage = await client.ListAsync(new()
         {
-            response = await client.ListAsync(new()
-            {
-                Page = ++page
-            }, cancellation);
+            Page = 1
+        }, cancellation);
 
-            starships.AddRange(response.Results);
-        } while (response.Next is not null);
+        // Create the Tasks for each page request.
+        var pages = await Task.WhenAll(
+            Enumerable.Range(2, (int) Math.Ceiling((double) (firstPage.Count - firstPage.Results.Count()) / firstPage.Results.Count()))
+            .Select(p => client.ListAsync(new()
+            {
+                Page = p
+            }, cancellation)));
+
+        // Add first page results and then the following page results.
+        // May need to consider possible duplicates, but that seems unlikely
+        // with the data coming from the SW API.
+        starships.AddRange(firstPage.Results.Union(pages.SelectMany(p => p.Results)));
 
         return starships;
     }

--- a/src/StarWars.AspNet.SWAPI/StarWars.AspNet.SWAPI.csproj
+++ b/src/StarWars.AspNet.SWAPI/StarWars.AspNet.SWAPI.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 
     <PackageId>StarWars.AspNet.SWAPI</PackageId>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Authors>Davis Templeton</Authors>
     <Company>Davis Templeton</Company>
     <Product>StarWars.AspNet.SWAPI</Product>

--- a/tests/StarWars.AspNet.Api.Testcontainers/StarWars.AspNet.Api.Testcontainers.csproj
+++ b/tests/StarWars.AspNet.Api.Testcontainers/StarWars.AspNet.Api.Testcontainers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 
     <PackageId>StarWars.AspNet.Api.Testcontainers</PackageId>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Authors>Davis Templeton</Authors>
     <Company>Davis Templeton</Company>
     <Product>StarWars.AspNet.Api.Testcontainers</Product>

--- a/tests/StarWars.AspNet.Api.Testcontainers/StarWarsApiBuilder.cs
+++ b/tests/StarWars.AspNet.Api.Testcontainers/StarWarsApiBuilder.cs
@@ -11,7 +11,7 @@ namespace StarWars.AspNet.Api.Testcontainers;
 public class StarWarsApiBuilder
     : ContainerBuilder<StarWarsApiBuilder, StarWarsApiContainer, StarWarsApiConfiguration>
 {
-    public const string Image = "localhost/starwars.aspnet.api:1.3.0";
+    public const string Image = "localhost/starwars.aspnet.api:1.3.1";
 
     public const ushort HttpPort = 8080;
     public const ushort HttpsPort = 8081;


### PR DESCRIPTION
This change set is a bit of a speed optimization change. Instead of making the request to get a single page at a time. This changes the method for pulling all the data from the SW API to pull the first page and then use the data from the first page to figure out how many other pages and what pages to pull and then combine all of those into a single collection to return. I would be interested to see the time benchmark comparisons between the two implementation. This became the process in the https://github.com/BashfulBandit/StarWars.Node version of this API because of the speed at which the process in that implementation was slow. This just brings the C# version in line to also be more performant.